### PR TITLE
Splash Page Play Button, Annotate Page Prompt text color

### DIFF
--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -270,7 +270,7 @@
           <br />
           <small class="text-muted">Human-Written Prompt:</small>
 
-          <p style="margin-top: 0.5rem">{{prompt.body}}</p>
+          <p clase="alert alert-info" style="margin-top: 0.5rem">{{prompt.body}}</p>
 
           <small class="text-muted">Continuation of text:</small>
 

--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -270,7 +270,7 @@
           <br />
           <small class="text-muted">Human-Written Prompt:</small>
 
-          <p clase="alert alert-info" style="margin-top: 0.5rem">{{prompt.body}}</p>
+          <p class="alert alert-info" style="margin-top: 0.5rem">{{prompt.body}}</p>
 
           <small class="text-muted">Continuation of text:</small>
 

--- a/annotation/core/templates/splash.html
+++ b/annotation/core/templates/splash.html
@@ -54,8 +54,21 @@
             to notice generated text in, and how the amount of randomness in the generated text impacts how easy the game is.
             Your contributions will be used to answer these research questions.
           </p>
+          
+          <div class="py-5" style="text-align: center">
+            <button class="btn btn-info btn-lg" style="height: 200px; width: 80%; max-width: 400px; font-size: 40px; font-weight: bold" 
+                onclick=toggleLogIn>
+              PLAY GAME
+            </button>
+          </div>
+          
+          <script>
+            function toggleLogIn() {
+              document.getElementById("login_signup").style.display = "block";
+            }
+          </script>
 
-          <div class="row">
+          <div class="row" id="login_signup" style="display: none">
             <div class="col-md-6">
               <br />
               <h2 class="text-muted"> <strong> Sign Up </strong> </h2>
@@ -96,11 +109,12 @@
                 <button type="submit" class="btn btn-info">Log In</button>
               </form>
             </div>
-            <div class="col-md-12" style="margin-top: 3rem">
-              <p class="text-muted">
-              Made by researchers at the University of Pennsylvania. Art credit to <a href="https://www.linkedin.com/in/trungtuanle">Trung Le</a>.
-              </p>
-            </div>
+            
+          </div>
+          <div style="margin-top: 3rem; text-align: center">
+            <p class="text-muted">
+            Made by researchers at the University of Pennsylvania. Art credit to <a href="https://www.linkedin.com/in/trungtuanle">Trung Le</a>.
+            </p>
           </div>
         </div>
         <div class="col-md" />

--- a/annotation/core/templates/splash.html
+++ b/annotation/core/templates/splash.html
@@ -17,6 +17,11 @@
       gtag('js', new Date());
       gtag('config', 'UA-104989157-3');
     </script>
+    <style>
+      html {
+        scroll-behavior: smooth;
+      }; 
+    </style>
   </head>
 
   <body>
@@ -56,15 +61,16 @@
           </p>
           
           <div class="py-5" style="text-align: center">
-            <button class="btn btn-info btn-lg" style="height: 200px; width: 80%; max-width: 400px; font-size: 40px; font-weight: bold" 
-                onclick=toggleLogIn>
+            <button id="play_game"class="btn btn-info btn-lg" style="height: 200px; width: 80%; max-width: 400px; font-size: 40px; font-weight: bold"
+                onclick="toggleLogIn()">
               PLAY GAME
             </button>
           </div>
           
           <script>
             function toggleLogIn() {
-              document.getElementById("login_signup").style.display = "block";
+              document.getElementById('login_signup').style.display = "";
+              window.scrollTo(0,document.body.scrollHeight);
             }
           </script>
 


### PR DESCRIPTION
Splash page "Play Game" button reveals the signin/login section by scroll.
 
Annotate page has the initial prompt in color box.

<img width="1166" alt="Screen Shot 2020-09-04 at 1 48 50 PM" src="https://user-images.githubusercontent.com/20518710/92271269-7e14b900-eeb5-11ea-8130-d020d681935d.png">
<img width="786" alt="Screen Shot 2020-09-04 at 1 49 20 PM" src="https://user-images.githubusercontent.com/20518710/92271274-81a84000-eeb5-11ea-93e4-a7bb22dd1155.png">
<img width="860" alt="Screen Shot 2020-09-04 at 1 49 27 PM" src="https://user-images.githubusercontent.com/20518710/92271282-84a33080-eeb5-11ea-8932-e795e3d84bd1.png">


