### PR TITLE
Fixed generations being too short

### DIFF
--- a/generation/generation_analyzer.py
+++ b/generation/generation_analyzer.py
@@ -17,9 +17,21 @@ with open(args.file, 'r') as f:
     p_value_cnt = Counter([gen['p'] for gen in data['generations']])
     both_cnt = Counter([(len(gen['prompt']),gen['p']) for gen in data['generations']])
 
+    total_num_issues = 0
+    # Note: check for if length adds up to 10
+    for gen in data['generations']:
+      prompt_len = len(gen['prompt'])
+      gen_len = len(gen['generation'])
+      if prompt_len + gen_len < 10:
+        total_num_issues += 1
+        print(gen['prompt-index'])
+
     print("Analysis results for file: " + str(args.file))
     print("-------------------------")
     print("Total Number of Generations: " + str(num_gens))
+    print("-------------------------")
+    print("Total Number of Generations that don't add up to 10: " + str(total_num_issues))
+    print("% bugged generations: " + str(float(total_num_issues) / float(num_gens)))
     print("-------------------------")
     print("Expected number of Generations per prompt length: " + str(num_gens/10))
     print("Expected number of Generations per p value: " + str(num_gens/11))

--- a/generation/inference_scripts/roft_ctrl_generator.py
+++ b/generation/inference_scripts/roft_ctrl_generator.py
@@ -133,6 +133,11 @@ with open(local_file_path, 'r') as f:
     prompt_length = int((i / prompts_per_length) + 1)
     p_value = round(math.floor(float(float(i%prompts_per_length) / (float(prompts_per_length) / 11.0))) / 10.0, 1) if args.vary_p else 0.4
 
+    # If the prompt isn't long enough to support the prompt_length we want, continue
+    if len(data['prompts'][i]) < prompt_length:
+      failure_causes[5] += 1
+      continue
+
     # Sample and tokenize the prompts for this batch
     raw_prompt = data['prompts'][i][:prompt_length]
     control_code, prompt = ctrl_process_prompt(args.control_code, copy.deepcopy(raw_prompt))

--- a/generation/inference_scripts/roft_gpt2_generator.py
+++ b/generation/inference_scripts/roft_gpt2_generator.py
@@ -109,6 +109,11 @@ with open(local_file_path, 'r') as f:
     prompt_length = int((i / prompts_per_length) + 1)
     p_value = round(math.floor(float(float(i%prompts_per_length) / (float(prompts_per_length) / 11.0))) / 10.0, 1) if args.vary_p else 0.4
 
+    # If the prompt isn't long enough to support the prompt_length we want, continue
+    if len(data['prompts'][i]) < prompt_length:
+      failure_causes[5] += 1
+      continue
+
     # Sample and tokenize the prompts for this batch
     prompt = data['prompts'][i][:prompt_length]
     inputs = tokenizer.encode(' '.join(prompt), return_tensors="pt")
@@ -176,6 +181,7 @@ with open(local_file_path, 'r') as f:
   print("Line too short: " + str(failure_causes[2]))
   print("Repetitive: " + str(failure_causes[3]))
   print("No Verb Present: " + str(failure_causes[4]))
+  print("Prompt too short: " + str(failure_causes[5]))
 
 # Save the prompts to the json file
 to_save = {


### PR DESCRIPTION
Fixed the issue where occasionally our generations were less than 10 sentences long.
The error was a downstream error from a binary flag not being set correctly in prompt sampling and only happens during the "all human" sampling (i.e. empty generation).

tl;dr prompt files should only contain len 10 prompts. However, when sampling prompts I didn't set the `REJECT_TOO_SHORT` flag to True and so the prompt files now contain some prompts that are less than 10 long. I added a check on the generation side for this.

I also added an analyzer script that takes in a generation file and gives a bunch of statistics on it. Should be pretty useful to have