### PR TITLE
Fine-Tuning script and Interactive model testing script

### DIFF
--- a/generation/finetuning_scripts/gpt2_interactive_test.py
+++ b/generation/finetuning_scripts/gpt2_interactive_test.py
@@ -1,0 +1,21 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-m','--model_name', help="Model Name ('gpt2','gpt2-medium','gpt2-large','gpt2-xl') or a finetuned model name", type=str, required=True)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+model = AutoModelForCausalLM.from_pretrained(args.model_name).cuda()
+
+while(True):
+    inputs = input("Input a prompt for the model: ")
+    input_tensor = tokenizer.encode(inputs, return_tensors='pt').to(model.device)
+    outputs = model.generate(input_tensor,
+                             do_sample=True,
+                             top_p=0.7,
+                             repetition_penalty=1.2,
+                             pad_token_id=tokenizer.eos_token_id,
+                             max_length=256)
+    out = [tokenizer.decode(x) for x in outputs][0]
+    print("Output:\n" + out)
+    print("---------------------------\n")

--- a/generation/finetuning_scripts/roft_gpt2_finetuning.py
+++ b/generation/finetuning_scripts/roft_gpt2_finetuning.py
@@ -1,0 +1,86 @@
+import argparse, json, subprocess
+from datasets import Dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments, DataCollatorForLanguageModeling, pipeline
+
+''' Custom encode function used to process data in the data collator before finetuning 
+    the encode function truncates each data line and runs the tokenizer on the batch '''
+def encode(batch): 
+    return tokenizer([x[:min(len(x),512)] for x in batch['prompts']], truncation=True, padding=True)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-d','--dataset', help="Dataset ('nyt', 'reddit-stories', 'speeches', or 'wikihow')", type=str, required=True)
+parser.add_argument('-m','--model_name', help="Model Name ('gpt2','gpt2-medium','gpt2-large','gpt2-xl')", type=str, required=True)
+args = parser.parse_args()
+
+# Download the sampling file from the Google Cloud bucket
+train_filename = 'prompts-{}.json'.format('-'.join([args.dataset, 'train']))
+train_file_url = 'gs://roft_datasets/prompts/' + args.dataset + '/' + train_filename
+train_local_file_path = './' + args.dataset + '/' + train_filename
+command = "gsutil cp {0} {1}".format(train_file_url, train_local_file_path)
+t_process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+
+dev_filename = 'prompts-{}.json'.format('-'.join([args.dataset, 'dev']))
+dev_file_url = 'gs://roft_datasets/prompts/' + args.dataset + '/' + dev_filename
+dev_local_file_path = './' + args.dataset + '/' + dev_filename
+command = "gsutil cp {0} {1}".format(dev_file_url, dev_local_file_path)
+d_process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+
+t_process.wait()
+d_process.wait()
+
+# Initialize the tokenizer, model, and data collator
+tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+tokenizer.pad_token = tokenizer.eos_token
+model = AutoModelForCausalLM.from_pretrained(args.model_name).cuda()
+data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+# Load the json
+with open(train_local_file_path, 'r') as f:
+  train_data = json.load(f)
+
+with open(dev_local_file_path, 'r') as f:
+  dev_data = json.load(f)
+  
+t_data_processed = dict()
+t_prompts = [' '.join(x) for x in train_data['prompts']]
+t_data_processed['prompts'] = t_prompts
+t_recipes = Dataset.from_dict(t_data_processed)
+t_processed = t_recipes.map(encode, batched=True, batch_size=1000)
+t_processed.set_format('torch', columns=['input_ids', 'attention_mask'])
+
+d_data_processed = dict()
+d_prompts = [' '.join(x) for x in dev_data['prompts']]
+d_data_processed['prompts'] = d_prompts
+d_recipes = Dataset.from_dict(d_data_processed)
+d_processed = d_recipes.map(encode, batched=True, batch_size=1000)
+d_processed.set_format('torch', columns=['input_ids', 'attention_mask'])
+
+training_args = TrainingArguments(
+    output_dir='./',
+    overwrite_output_dir=True,
+    num_train_epochs=1,
+    per_device_train_batch_size=16,
+    per_device_eval_batch_size=16,
+    logging_steps=100,
+    weight_decay=0.01,
+    logging_dir='./logs',
+)
+
+trainer = Trainer(
+    model=model,
+    tokenizer=tokenizer,
+    args=training_args,
+    data_collator=data_collator,
+    train_dataset=t_processed,
+    eval_dataset=d_processed,
+)
+
+trainer.train()
+
+trainer.save_model('./finetuned')
+
+finetuned = pipeline('text-generation', model='./finetuned', device=0)
+standard = pipeline('text-generation', model=args.model_name, device=0)
+
+print(finetuned('Ham Sandwich'))
+print(standard('Ham Sandwich'))

--- a/generation/finetuning_scripts/roft_gpt2_finetuning.py
+++ b/generation/finetuning_scripts/roft_gpt2_finetuning.py
@@ -1,32 +1,47 @@
-import argparse, json, subprocess
+import argparse, json, subprocess, os
 from datasets import Dataset
-from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments, DataCollatorForLanguageModeling, pipeline
+from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments, DataCollatorForLanguageModeling
 
-''' Custom encode function used to process data in the data collator before finetuning 
-    the encode function truncates each data line and runs the tokenizer on the batch '''
-def encode(batch): 
-    return tokenizer([x[:min(len(x),512)] for x in batch['prompts']], truncation=True, padding=True)
+''' Downloads the prompts json file from the roft GCloud bucket '''
+def download_sampling_file(dataset, split):
+  filename = 'prompts-{}.json'.format('-'.join([dataset, split]))
+  file_url = 'gs://roft_datasets/prompts/' + dataset + '/' + filename
+  local_path = './' + dataset + '/' + filename
+  if not os.path.exists(local_path):
+    command = "gsutil cp {0} {1}".format(file_url, local_path)
+    process = subprocess.Popen(command.split(), stdout=subprocess.PIPE).wait()
+  return local_path
+
+''' Encode function used to process data before finetuning.
+    Each input example is tokenized and then truncated/padded to "max_length" '''
+def encode(batch):
+    return tokenizer(batch['prompts'], truncation=True, padding=True, max_length=256)
+
+''' Converts the prompts json file into a HuggingFace Dataset object '''
+def roft_prompts_json_to_dataset(file_path):
+  with open(file_path, 'r') as f:
+    data = json.load(f)
+    prompts = [' '.join(x) for x in data['prompts']]
+  return Dataset.from_dict(dict(prompts=prompts))
+
+''' Tokenize and preprocess the Dataset object to prep for finetuning '''
+def tokenize_dataset(dataset, tokenizer):
+  tokenized = dataset.map(encode, batched=True, batch_size=1000)
+  tokenized.set_format('torch', columns=['input_ids', 'attention_mask'])
+  return tokenized
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-d','--dataset', help="Dataset ('nyt', 'reddit-stories', 'speeches', or 'wikihow')", type=str, required=True)
 parser.add_argument('-m','--model_name', help="Model Name ('gpt2','gpt2-medium','gpt2-large','gpt2-xl')", type=str, required=True)
 args = parser.parse_args()
 
-# Download the sampling file from the Google Cloud bucket
-train_filename = 'prompts-{}.json'.format('-'.join([args.dataset, 'train']))
-train_file_url = 'gs://roft_datasets/prompts/' + args.dataset + '/' + train_filename
-train_local_file_path = './' + args.dataset + '/' + train_filename
-command = "gsutil cp {0} {1}".format(train_file_url, train_local_file_path)
-t_process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+# Download the prompt files from the roft GCloud bucket
+train_local_file_path = download_sampling_file(args.dataset, 'train')
+dev_local_file_path = download_sampling_file(args.dataset, 'dev')
 
-dev_filename = 'prompts-{}.json'.format('-'.join([args.dataset, 'dev']))
-dev_file_url = 'gs://roft_datasets/prompts/' + args.dataset + '/' + dev_filename
-dev_local_file_path = './' + args.dataset + '/' + dev_filename
-command = "gsutil cp {0} {1}".format(dev_file_url, dev_local_file_path)
-d_process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
-
-t_process.wait()
-d_process.wait()
+# Load the prompt json files into dataset objects
+train_dataset = roft_prompts_json_to_dataset(train_local_file_path)
+dev_dataset = roft_prompts_json_to_dataset(dev_local_file_path)
 
 # Initialize the tokenizer, model, and data collator
 tokenizer = AutoTokenizer.from_pretrained(args.model_name)
@@ -34,36 +49,25 @@ tokenizer.pad_token = tokenizer.eos_token
 model = AutoModelForCausalLM.from_pretrained(args.model_name).cuda()
 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-# Load the json
-with open(train_local_file_path, 'r') as f:
-  train_data = json.load(f)
+# Tokenize the datasets with the appropriate tokenizer
+train_tok = tokenize_dataset(train_dataset, tokenizer)
+dev_tok = tokenize_dataset(dev_dataset, tokenizer)
 
-with open(dev_local_file_path, 'r') as f:
-  dev_data = json.load(f)
-  
-t_data_processed = dict()
-t_prompts = [' '.join(x) for x in train_data['prompts']]
-t_data_processed['prompts'] = t_prompts
-t_recipes = Dataset.from_dict(t_data_processed)
-t_processed = t_recipes.map(encode, batched=True, batch_size=1000)
-t_processed.set_format('torch', columns=['input_ids', 'attention_mask'])
-
-d_data_processed = dict()
-d_prompts = [' '.join(x) for x in dev_data['prompts']]
-d_data_processed['prompts'] = d_prompts
-d_recipes = Dataset.from_dict(d_data_processed)
-d_processed = d_recipes.map(encode, batched=True, batch_size=1000)
-d_processed.set_format('torch', columns=['input_ids', 'attention_mask'])
-
+# Initialize the Trainer
 training_args = TrainingArguments(
     output_dir='./',
     overwrite_output_dir=True,
     num_train_epochs=1,
-    per_device_train_batch_size=16,
-    per_device_eval_batch_size=16,
+    save_total_limit=1,
+    evaluation_strategy="steps",
+    per_device_train_batch_size=1,
+    per_device_eval_batch_size=1,
     logging_steps=100,
+    eval_steps=10000,
     weight_decay=0.01,
     logging_dir='./logs',
+    load_best_model_at_end=True,
+    metric_for_best_model="eval_loss"
 )
 
 trainer = Trainer(
@@ -71,16 +75,12 @@ trainer = Trainer(
     tokenizer=tokenizer,
     args=training_args,
     data_collator=data_collator,
-    train_dataset=t_processed,
-    eval_dataset=d_processed,
+    train_dataset=train_tok,
+    eval_dataset=dev_tok,
 )
 
+# Train the model
 trainer.train()
 
+# Save the best model
 trainer.save_model('./finetuned')
-
-finetuned = pipeline('text-generation', model='./finetuned', device=0)
-standard = pipeline('text-generation', model=args.model_name, device=0)
-
-print(finetuned('Ham Sandwich'))
-print(standard('Ham Sandwich'))


### PR DESCRIPTION
Adds two scripts:
- `./generation/finetuning_scripts/roft_gpt2_finetuning.py`
    - Takes in two arguments `-d dataset` and `-m model_name` and fine-tunes a model of type model_name on the dataset
    - Fine-tuned models are trained on the 'train' split and the best performing checkpoint on the 'dev' split is kept at the end
- `./generation/finetuning_scripts/gpt2_interactive_test.py`
    - Takes one argument `-m model_name` (the path to the model) and loads the model in an interactive loop
    - The user can prompt the model and see the output live to experiment with model quality and generation parameters