### PR TITLE
Fix for "Profile" and "Log Out" appearing on Login page

### DIFF
--- a/annotation/core/views.py
+++ b/annotation/core/views.py
@@ -71,6 +71,10 @@ def join(request):
       if not Profile.objects.get(user=request.user).is_temporary:
         return redirect('/play')
 
+      return render(request, 'join.html', {
+          'profile': Profile.objects.get(user=request.user)
+      })
+
     return render(request, 'join.html')
 
 


### PR DESCRIPTION
Bug fix for #138 . This is a branch off of the previous splash page fix branch.

Reason for bug was that we weren't passing in `profile` objects to files that extended `base.html` (such as `join.html`). 