### PR TITLE
Added Go Back button to annotation page

### DIFF
--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -277,7 +277,6 @@
       $("#selection").show();
       $("#analysis").hide();
       $("#revision").hide();
-      // $("#revision").val(all_sentences[current_sentence - 1]);
     });
 
     $("#human").click(function(e) {
@@ -366,7 +365,7 @@
             <input type="text" id="other_reason" name="other_reason" style="margin-bottom: 1rem; margin-top: .4rem" class="form-control" placeholder="Describe the problem you noticed" />
           </div>
           <button type="button" id="go_back" class="btn btn-secondary"> Go Back </button>
-          <button type="submit" id="reveal" class="btn btn-info"> Reveal </button>
+          <button type="submit" class="btn btn-info"> Reveal </button>
         </form>
       </div>
 

--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -140,7 +140,7 @@
         "common_sense": common_sense,
         "coreference": coreference,
         "generic": generic,
-        "other_reason": other_reason, 
+        "other_reason": other_reason,
         "points": points,
         "attention_check": attention_check
       },
@@ -245,7 +245,7 @@
             "common_sense": common_sense,
             "coreference": coreference,
             "generic": generic,
-            "other_reason": other_reason, 
+            "other_reason": other_reason,
             "points": points,
             "attention_check": attention_check
           },
@@ -270,6 +270,13 @@
       $("#selection").hide();
       $("#analysis").show();
       $("#revision").show();
+      // $("#revision").val(all_sentences[current_sentence - 1]);
+    });
+
+    $("#go_back").click(function() {
+      $("#selection").show();
+      $("#analysis").hide();
+      $("#revision").hide();
       // $("#revision").val(all_sentences[current_sentence - 1]);
     });
 
@@ -330,7 +337,7 @@
 
       <div class="card-body" id="analysis" style="display: none">
         <p class="text-info">
-          Why do you think this sentence is computer-generated? Select all that apply. 
+          Why do you think this sentence is computer-generated? Select all that apply.
         </p>
         <form id="revision-form">
           <div>
@@ -358,7 +365,8 @@
             <div class="text-dark">Other</div>
             <input type="text" id="other_reason" name="other_reason" style="margin-bottom: 1rem; margin-top: .4rem" class="form-control" placeholder="Describe the problem you noticed" />
           </div>
-          <button type="submit" class="btn btn-info"> Reveal </button>
+          <button type="button" id="go_back" class="btn btn-secondary"> Go Back </button>
+          <button type="submit" id="reveal" class="btn btn-info"> Reveal </button>
         </form>
       </div>
 
@@ -371,7 +379,7 @@
   </div>
   <div class="col-md" />
 </div>
-  
+
   <script>
     $(function() {
       // This function gets cookie with a given name


### PR DESCRIPTION
Requested in Issue #87 

Adds a "Go Back" button to the reason checkbox section to allow people to go back before having locked in their answer.

<img width="1078" alt="backbutton" src="https://user-images.githubusercontent.com/14120375/114927253-44b70b00-9dff-11eb-9290-90e8f90c7c0c.png">
<img width="892" alt="back" src="https://user-images.githubusercontent.com/14120375/114927268-484a9200-9dff-11eb-9915-a9b27e690d9c.png">
