### PR TITLE
Password verification

### DIFF
--- a/annotation/core/templates/signup.html
+++ b/annotation/core/templates/signup.html
@@ -14,8 +14,20 @@
           <h2 class="text-muted"> <strong> Sign Up </strong> </h2>
           <p class="text-muted" style="font-weight: 300">By signing up for an account, you'll have access to stats like the number of questions you've answered. If you do well, your username may appear on the leaderboard!</p>
           <form style="width: 80%" action="/signup/" method="POST">
-            {% if 'error' in request.GET %}
-              <p class="text-danger">Username already exists.</p>
+            {% if error == "0" %}
+              <p class="text-danger">User already exists.</p>
+            {% elif error == "1" %}
+              <p class="text-danger">Username must not be an email address.</p>
+            {% elif error == "2" %}
+              <p class="text-danger">Passwords do not match.</p>
+            {% elif error == "3" %}
+              <p class="text-danger">Password is too short. It must contain at least 8 characters.</p>
+            {% elif error == "4" %}
+              <p class="text-danger">Password is too common.</p>
+            {% elif error == "5" %}
+              <p class="text-danger">Password can not be entirely numeric.</p>
+            {% elif error == "6" %}
+              <p class="text-danger">Unknown Error</p>
             {% endif %}
             {% csrf_token %}
             <div class="form-group">
@@ -25,6 +37,10 @@
             <div class="form-group">
               <label class="text-muted" for="exampleInputPassword1">Password</label>
               <input name="password" type="password" class="form-control" id="exampleInputPassword1" placeholder="Choose a password here...">
+            </div>
+            <div class="form-group">
+              <label class="text-muted" for="exampleInputPassword2">Confirm Password</label>
+              <input name="password2" type="password" class="form-control" id="exampleInputPassword2" placeholder="Confirm Your Password...">
             </div>
             <div class="form-group">
               <label class="text-muted" for="user_source">Optional: How did you hear about RoFT?</label>

--- a/annotation/core/templates/signup.html
+++ b/annotation/core/templates/signup.html
@@ -40,7 +40,7 @@
             </div>
             <div class="form-group">
               <label class="text-muted" for="exampleInputPassword2">Confirm Password</label>
-              <input name="password2" type="password" class="form-control" id="exampleInputPassword2" placeholder="Confirm Your Password...">
+              <input name="password2" type="password" class="form-control" id="exampleInputPassword2" placeholder="Confirm your password...">
             </div>
             <div class="form-group">
               <label class="text-muted" for="user_source">Optional: How did you hear about RoFT?</label>

--- a/annotation/core/views.py
+++ b/annotation/core/views.py
@@ -9,6 +9,7 @@ from django.db.models import F, Q, Sum, Func, Avg, Count
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import ValidationError, validate_password, password_validators_help_text_html
 from markdown2 import markdown
 
 from core.models import Prompt, Generation, Annotation, Playlist, Profile, SEP, FeedbackOption
@@ -321,14 +322,40 @@ def log_in(request):
 
 def sign_up(request):
     if request.method == 'GET':
+      if request.GET:
+        return render(request, 'signup.html', {
+          'error': request.GET['error']
+        })
+      else:
         return render(request, 'signup.html')
 
     username = request.POST['username']
     password = request.POST['password']
+    password2 = request.POST['password2']
     user_source = request.POST['user_source']
 
     if User.objects.filter(username=username).exists():
-        return redirect('/signup?error=True')
+      return redirect('/signup?error=0')
+
+    if re.search('^(\w|\.|\_|\-)+[@](\w|\_|\-|\.)+[.]\w{2,3}$', username):
+      return redirect('/signup?error=1')
+
+    if password != password2:
+      return redirect('/signup?error=2')
+
+    try:
+      validate_password(password)
+    except ValidationError as e:
+      for error_string in e:
+        if error_string == 'This password is too short. It must contain at least 8 characters.':
+          return redirect('/signup?error=3')
+        elif error_string == 'This password is too common.':
+          return redirect('/signup?error=4')
+        elif error_string == 'This password is entirely numeric.':
+          return redirect('/signup?error=5')
+        else:
+          return redirect('/signup?error=6')
+
 
     # handle logic for saving progress
     if request.user.is_authenticated and Profile.objects.get(user=request.user).is_temporary:

--- a/annotation/trick/settings.py
+++ b/annotation/trick/settings.py
@@ -102,9 +102,6 @@ else:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
     {


### PR DESCRIPTION
Addresses #145 #136 and #86 

Changes:
- Passwords submitted to `signup()` are now verified using `django.contrib.auth.password_validation.validate_password` and are now subjected to the following criteria (#145)
    - Must be at least 8 characters
    - Must not be entirely numerical 
    - Must not be contained in a list of 20,000 common passwords
- Added a regex-based check in `/signup` that ensures that usernames are not email addresses (#86)
- `/signup` now has a "Confirm Password" box as shown below (Password and Confirm Password contents must be identical in order to successfully sign up) (#136)
<p align="center">
<img width="500" alt="スクリーンショット 2021-05-04 17 05 09" src="https://user-images.githubusercontent.com/14120375/117069793-ed6bd280-acfa-11eb-832b-41884c570c27.png">
</p>

Notes: 
- In order to implement this PR I changed how errors are passed to `/signup`. Now instead of calling `redirect('/signup?error=True')` I call `redirect('/signup?error={0, 1, 2, ... etc}')` with each number referring to a different error code that is then parsed by `signup.html` before displaying the message. This has the drawback of limiting us to only one error shown at a time, giving certain errors priority over others. (Snippets are shown below)
<p align="center">
<img width="500" alt="parse" src="https://user-images.githubusercontent.com/14120375/117071378-0b3a3700-acfd-11eb-875a-b1e39bc9e062.png">
</p>
<p align="center">
<img width="500" alt="parse" src="https://user-images.githubusercontent.com/14120375/117071385-0d9c9100-acfd-11eb-8eb0-5e145ae0d70e.png">
</p>
 
- I dislike this implementation but after messing with this for way too long I eventually gave up on implementing it in a better way. If anyone has any suggestions for how to pass data through a call to `redirect()` in a better way, I'm all ears.
