### PR TITLE
Require annotators to give reasoning behind annotations

### DIFF
--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -13,8 +13,8 @@
 ─██████──██████████─██████████████─██████──██████─████████████──────────██████─────██████──██████─██████████─██████████████─
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-This project is for research purposes *only*. Exploiting vulnerabilities in this 
-codebase does nothing but lose us time that we would prefer to spend doing actual 
+This project is for research purposes *only*. Exploiting vulnerabilities in this
+codebase does nothing but lose us time that we would prefer to spend doing actual
 research. So, please, be nice to the codebase.
 
 Thank you,
@@ -220,6 +220,10 @@ Thank you,
       const generic = $('#generic').is(":checked");
       const other_reason = $("#other_reason").val();
 
+      const any = grammar || repetition || irrelevant || contradicts_sentence ||
+                  contradicts_knowledge || common_sense || coreference ||
+                  generic || Boolean(other_reason);
+
       $("#note").val('');
       $('input[type=checkbox]').each(function() {
         this.checked = false;
@@ -238,37 +242,41 @@ Thank you,
       }
 
       // make ajax request to log annotation
-      console.log('Making ajax call with boundary = ' + current_sentence_index);
-      const url = '{% url "save" %}';
-      $.ajax({
-        type: 'POST',
-        url: url,
-        data: {
-          "boundary": current_sentence_index,
-          "text": text_id,
-          "name": name,
-          "playlist_id": playlist,
-          "grammar": grammar,
-          "repetition": repetition,
-          "irrelevant": irrelevant,
-          "contradicts_sentence": contradicts_sentence,
-          "contradicts_knowledge": contradicts_knowledge,
-          "common_sense": common_sense,
-          "coreference": coreference,
-          "generic": generic,
-          "other_reason": other_reason,
-          "points": points,
-          "attention_check": attention_check,
-          "timestamps": timestamps.join(',')
-        },
-        success: function (response) {
-          reveal_solutions();
-          show_points(points);
-        },
-        error: function (error) {
-          console.log(error);
-        }
-      });
+      if (any) {
+        console.log('Making ajax call with boundary = ' + current_sentence_index);
+        const url = '{% url "save" %}';
+        $.ajax({
+          type: 'POST',
+          url: url,
+          data: {
+            "boundary": current_sentence_index,
+            "text": text_id,
+            "name": name,
+            "playlist_id": playlist,
+            "grammar": grammar,
+            "repetition": repetition,
+            "irrelevant": irrelevant,
+            "contradicts_sentence": contradicts_sentence,
+            "contradicts_knowledge": contradicts_knowledge,
+            "common_sense": common_sense,
+            "coreference": coreference,
+            "generic": generic,
+            "other_reason": other_reason,
+            "points": points,
+            "attention_check": attention_check,
+            "timestamps": timestamps.join(',')
+          },
+          success: function (response) {
+            reveal_solutions();
+            show_points(points);
+          },
+          error: function (error) {
+            console.log(error);
+          }
+        });
+      } else {
+        $("#no-selection").show();
+      }
     }
 
     // adding new sentence
@@ -393,6 +401,9 @@ Thank you,
             <div class="text-dark">Other</div>
             <input type="text" id="other_reason" name="other_reason" style="margin-bottom: 1rem; margin-top: .4rem" class="form-control" placeholder="Describe the problem you noticed" />
           </div>
+          <p class="text-danger" id="no-selection" style="display: none">
+            Please select at least one Error Type
+          </p>
           <button type="button" id="go_back" class="btn btn-secondary"> Go Back </button>
           <button type="submit" class="btn btn-info"> Reveal </button>
         </form>


### PR DESCRIPTION
This PR addresses issue #187
- On attempting to select "Reveal" with no checkboxes selected and an empty field for "Other" the page will now reveal this red text that says "Please Select at least one Error Type". 
- Users will not be able to submit their annotation until at least one box is checked or something is written in the "Other" field

<img width="785" alt="スクリーンショット 2021-09-23 20 33 42" src="https://user-images.githubusercontent.com/14120375/134600962-cf1506de-2339-4d26-b868-58ed57cd5009.png">
