### PR TITLE
Fixed bug where all human broke submission

### DIFF
--- a/annotation/core/templates/annotate.html
+++ b/annotation/core/templates/annotate.html
@@ -206,6 +206,71 @@ Thank you,
       redraw_sentences(current_sentence);
     {% endif %}
 
+    function submit_annotation_all_human(e) {
+      e.preventDefault();
+
+      // get checkbox values and reset
+      const grammar = $('#grammar').is(":checked");
+      const repetition = $('#repetition').is(":checked");
+      const irrelevant = $('#irrelevant').is(":checked");
+      const contradicts_sentence = $('#contradicts_sentence').is(":checked");
+      const contradicts_knowledge = $('#contradicts_knowledge').is(":checked");
+      const common_sense = $('#common_sense').is(":checked");
+      const coreference = $('#coreference').is(":checked");
+      const generic = $('#generic').is(":checked");
+      const other_reason = $("#other_reason").val();
+
+      $("#note").val('');
+      $('input[type=checkbox]').each(function() {
+        this.checked = false;
+      });
+
+      const max_points = 5;
+      let points = 0;
+
+      const current_sentence_index = current_sentence - 1;
+      if (attention_check) {
+        points = 0;
+      } else if (current_sentence_index == boundary) {
+        points = max_points;
+      } else if (current_sentence_index > boundary) {
+        points = Math.max(max_points - Math.abs(boundary - current_sentence_index), 0);
+      }
+
+      // make ajax request to log annotation
+      console.log('Making ajax call with boundary = ' + current_sentence_index);
+      const url = '{% url "save" %}';
+      $.ajax({
+        type: 'POST',
+        url: url,
+        data: {
+          "boundary": current_sentence_index,
+          "text": text_id,
+          "name": name,
+          "playlist_id": playlist,
+          "grammar": grammar,
+          "repetition": repetition,
+          "irrelevant": irrelevant,
+          "contradicts_sentence": contradicts_sentence,
+          "contradicts_knowledge": contradicts_knowledge,
+          "common_sense": common_sense,
+          "coreference": coreference,
+          "generic": generic,
+          "other_reason": other_reason,
+          "points": points,
+          "attention_check": attention_check,
+          "timestamps": timestamps.join(',')
+        },
+        success: function (response) {
+          reveal_solutions();
+          show_points(points);
+        },
+        error: function (error) {
+          console.log(error);
+        }
+      });
+    }
+
     function submit_annotation(e) {
       e.preventDefault();
 
@@ -314,7 +379,7 @@ Thank you,
       $("#revision-form").hide();
       $("#selection").hide();
       $("#analysis").show();
-      submit_annotation(e);
+      submit_annotation_all_human(e);
     });
 
     $("#continue").click(function() {


### PR DESCRIPTION
This PR addresses Issue #190 
It adds another function `submit_annotation_all_human` which is created specifically for the purpose of submitting an all human annotation. This new function is identical to the old `submit_annotation` function except for the fact that it doesn't check to ensure that any checkboxes are checked before submitting